### PR TITLE
README.MD: Add *.swp and *.swo to .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ myvenv
 db.sqlite3
 /static
 .DS_Store
+*.swp
+*.swo
 ```
 
 <br>
@@ -159,4 +161,3 @@ application = StaticFilesHandler(get_wsgi_application())
 
 
 <br>
-


### PR DESCRIPTION
Linux makes temporary save files with .swo and .swp whenever a file is opened. This makes sure that git ignores these files.